### PR TITLE
Add links to component demos on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-icons/iron-icons.html">
   <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
   <link rel="import" href="../paper-button/paper-button.html">
+  <link rel="import" href="../paper-item/paper-item.html">
+  <link rel="import" href="../paper-item/paper-item-body.html">
   <link rel="import" href="../paper-styles/shadow.html">
   <link rel="import" href="app-layout.html">
   <link rel="import" href="site/device-viewer/device-layout-viewer.html">
@@ -211,6 +213,28 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background-size: contain;
     }
 
+    .scrolling-region {
+      position: relative;
+      height: 480px;
+      width: 100%;
+      overflow-y: auto;
+      /* fixes scroll track's z-index bug in safari*/
+      -webkit-transform: translateZ(0);
+      margin: 8px;
+      background-color: #fff;
+      @apply(--shadow-elevation-2dp);
+    }
+
+    .scrolling-region paper-list-item {
+      border-bottom: 1px solid #ececec;
+    }
+
+    .scrolling-region paper-button {
+      background-color: #4FB6F7;
+      color: #fff;
+      line-height: 1.0;
+    }
+
     @media (max-width: 1024px) {
 
       .heading {
@@ -368,6 +392,32 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         </template>
 
+      </div>
+
+    </section>
+
+    <section>
+
+      <h1>Demos</h1>
+
+      <p>The demos illustrate the use of individual App Layout components.</p>
+      <div class="grid">
+        <div class="scrolling-region">
+          <template is="dom-repeat" items="{{resources.demos}}">
+            <paper-item style="text-align: left">
+              <paper-item-body two-line>
+                <div>{{item.name}}</div>
+                <div secondary>{{item.desc}}</div>
+              </paper-item-body>
+              <a href="{{item.demoUrl}}" target="_blank" tabindex="-1">
+                <paper-button raised>View</paper-button>
+              </a>
+              <a href="{{item.sourceUrl}}" target="_blank" tabindex="-1">
+                <paper-button raised>Source</paper-button>
+              </a>
+            </paper-item>
+          </template>
+        </div>
       </div>
 
     </section>

--- a/site/resources.json
+++ b/site/resources.json
@@ -37,6 +37,122 @@
       "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/templates/landing-page"
     }
   ],
+  "demos": [
+    {
+      "name": "App Box: Splash Page",
+      "desc": "app-boxes with parallax effect in full page",
+      "demoUrl": "app-box/demo/document-scroll.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-box/demo/document-scroll.html"
+    },
+    {
+      "name": "App Box; Splash Region",
+      "desc": "Using app-boxes in a scrolling region",
+      "demoUrl": "app-box/demo/scrolling-region.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-box/demo/scrolling-region.html"
+    },
+    {
+      "name": "App Drawer: Simple Left Drawer",
+      "desc": "A basic example with left side drawer",
+      "demoUrl": "app-drawer/demo/demo1.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-drawer/demo/demo1.html"
+    },
+    {
+      "name": "App Drawer: Right Drawer with Icons",
+      "desc": "Right side drawer with several icons",
+      "demoUrl": "app-drawer/demo/demo2.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-drawer/demo/demo2.html"
+    },
+    {
+      "name": "App Drawer Layout: Simple Layout",
+      "desc": "A simple left hand layout",
+      "demoUrl": "app-drawer-layout/demo/demo1.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-drawer-layout/demo/demo1.html"
+    },
+    {
+      "name": "App Drawer Layout: Left Drawer and Right Drawer",
+      "desc": "Left drawer with swipeable right drawer",
+      "demoUrl": "app-drawer-layout/demo/demo2.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-drawer-layout/demo/demo2.html"
+    },
+    {
+      "name": "App Header: Contacts Page",
+      "desc": "Header with resize, blend, parallax effects and shrinking FAB",
+      "demoUrl": "app-header/demo/contacts.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/contacts.html"
+    },
+    {
+      "name": "App Header: Simple Demo 1",
+      "desc": "Header with resize, blend, parallax effects",
+      "demoUrl": "app-header/demo/demo1.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/demo1.html"
+    },
+    {
+      "name": "App Header: Simple Demo 2",
+      "desc": "Header with tall toolbar",
+      "demoUrl": "app-header/demo/demo2.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/demo2.html"
+    },
+    {
+      "name": "App Header: Simple Demo 3",
+      "desc": "Header with blended bg color change",
+      "demoUrl": "app-header/demo/demo3.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/demo3.html"
+    },
+    {
+      "name": "App Header: Give Page",
+      "desc": "Header with resize snapped title and fade effects",
+      "demoUrl": "app-header/demo/give.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/give.html"
+    },
+    {
+      "name": "App Header: No Effects",
+      "desc": "A simple header without effects",
+      "demoUrl": "app-header/demo/no-effects.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/no-effects.html"
+    },
+    {
+      "name": "App Header: Notes Page",
+      "desc": "Fixed header",
+      "demoUrl": "app-header/demo/notes.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/notes.html"
+    },
+    {
+      "name": "App Header: Pesto Page",
+      "desc": "Condensing fixed header",
+      "demoUrl": "app-header/demo/pesto.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header/demo/pesto.html"
+    },
+    {
+      "name": "App Header Layout: Simple Demo",
+      "desc": "A basic example of layout",
+      "demoUrl": "app-header-layout/demo/demo1.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header-layout/demo/demo1.html"
+    },
+    {
+      "name": "App Header Layout: Scrollable Demo",
+      "desc": "A layout embedded in a region",
+      "demoUrl": "app-header-layout/demo/demo2.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header-layout/demo/demo2.html"
+    },
+    {
+      "name": "App Header Layout: Music",
+      "desc": "A more complex example, with layout embedded in App Box",
+      "demoUrl": "app-header-layout/demo/music.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-header-layout/demo/music.html"
+    },
+    {
+      "name": "App Scrollpos Control: Simple Demo",
+      "desc": "Remembering position after iron page change",
+      "demoUrl": "app-scrollpos-control/demo/index.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/app-scrollpos-control/demo/index.html"
+    },
+    {
+      "name": "App Toolbar: Gallery",
+      "desc": "Several toolbar variations",
+      "demoUrl": "app-toolbar/demo/index.html",
+      "sourceUrl": "https://github.com/PolymerLabs/app-layout/tree/master/web/app-toolbar/demo/index.html"
+    }
+  ],
   "patterns": [
     {
       "name": "Transform Navigation",


### PR DESCRIPTION
Provides a scrollable box including links to view individual component demos and their source.  I used a similar one on the Dart wrappers and thought you might find it useful too.