### PR TITLE
Fixed indents for app-header demo files

### DIFF
--- a/app-header/demo/blend-background-1.html
+++ b/app-header/demo/blend-background-1.html
@@ -94,7 +94,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header condenses reveals effects="waterfall resize-title blend-background parallax-background">
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
       <h4 condensed-title>What is material? &mdash; Environment</h4>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>

--- a/app-header/demo/blend-background-2.html
+++ b/app-header/demo/blend-background-2.html
@@ -98,7 +98,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header condenses reveals effects="waterfall resize-title blend-background parallax-background">
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
       <h4 condensed-title>What is material? &mdash; Environment</h4>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>

--- a/app-header/demo/blend-background-3.html
+++ b/app-header/demo/blend-background-3.html
@@ -95,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header condenses reveals effects="waterfall resize-title blend-background parallax-background">
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
       <h4 condensed-title>What is material? &mdash; Environment</h4>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>

--- a/app-header/demo/contacts.html
+++ b/app-header/demo/contacts.html
@@ -93,7 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header effects="waterfall resize-title blend-background parallax-background" condenses reveals>
     <app-toolbar>
-     <paper-icon-button icon="arrow-back"></paper-icon-button>
+      <paper-icon-button icon="arrow-back"></paper-icon-button>
       <div condensed-title>Pharrell Williams</div>
       <paper-icon-button icon="create"></paper-icon-button>
       <paper-icon-button icon="more-vert"></paper-icon-button>

--- a/app-header/demo/give.html
+++ b/app-header/demo/give.html
@@ -102,7 +102,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       effects="waterfall resize-snapped-title fade-background"
       effects-config='{"resize-snapped-title": {"startsAt": 0.8, "duration": "100ms"}, "fade-background": {"startsAt": 0.8, "endsAt": 0.9}}'>
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
       <h4 condensed-title>GiveDirectly</h4>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>

--- a/app-header/demo/music.html
+++ b/app-header/demo/music.html
@@ -182,7 +182,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header reveals>
     <app-toolbar>
-     <paper-icon-button icon="arrow-back"></paper-icon-button>
+      <paper-icon-button icon="arrow-back"></paper-icon-button>
       <div title></div>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>

--- a/app-header/demo/no-effects.html
+++ b/app-header/demo/no-effects.html
@@ -54,7 +54,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header condenses reveals>
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
     </app-toolbar>
   </app-header>
 

--- a/app-header/demo/notes.html
+++ b/app-header/demo/notes.html
@@ -137,7 +137,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header fixed>
     <app-toolbar>
-     <paper-icon-button icon="menu"></paper-icon-button>
+      <paper-icon-button icon="menu"></paper-icon-button>
       <div title>Notes</div>
       <paper-icon-button icon="search"></paper-icon-button>
     </app-toolbar>


### PR DESCRIPTION
Quick resolution for minor issue #221. 
One space indents before the first paper-icon-button elements: 
`| <paper-icon-button icon="menu"></paper-icon-button>  `
