### PR TITLE
Removed bottom offset to fix scrolling drawer contents

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -58,7 +58,7 @@ Custom property                  | Description                            | Defa
         position: fixed;
         top: -120px;
         right: 0;
-        bottom: -120px;
+        bottom: 0;
         left: 0;
 
         visibility: hidden;


### PR DESCRIPTION
This fixes the height for the drawer so scrolling contents are handled correctly.  Being new to Polymer I'm not sure if there's a reason for bottom having been -120px (like top), but in my project changing it to 0 didn't have any negative impact.  If there's a reason this must be -120px I propose a variable which can be set to adjust for this.  The only other alternative I had was to hard code a margin-bottom of 120px when I use app-drawer, which doesn't seem very stable.