### PR TITLE
Add fullbleed attribute to app-header-layout

### DIFF
--- a/app-header-layout/README.md
+++ b/app-header-layout/README.md
@@ -32,3 +32,11 @@ Using an own scrolling region:
   </div>
 </app-header-layout>
 ```
+
+Add the `fullbleed` attribute to app-header-layout to make it fit the size of its container:
+
+```html
+<app-header-layout fullbleed>
+ ...
+</app-header-layout>
+```

--- a/app-header-layout/app-header-layout.html
+++ b/app-header-layout/app-header-layout.html
@@ -46,11 +46,20 @@ Using an own scrolling region:
 </app-header-layout>
 ```
 
+Add the `fullbleed` attribute to app-header-layout to make it fit the size of its container:
+
+```html
+<app-header-layout fullbleed>
+ ...
+</app-header-layout>
+```
+
 @group App Elements
 @element app-header-layout
 @demo app-header-layout/demo/simple.html Simple Demo
 @demo app-header-layout/demo/scrolling-region.html Scrolling Region
 @demo app-header-layout/demo/music.html Music Demo
+@demo app-header-layout/demo/footer.html Footer Demo
 -->
 
 <dom-module id="app-header-layout">
@@ -58,7 +67,6 @@ Using an own scrolling region:
     <style>
       :host {
         display: block;
-
         /**
          * Force app-header-layout to have its own stacking context so that its parent can
          * control the stacking of it relative to other elements (e.g. app-drawer-layout).
@@ -69,18 +77,33 @@ Using an own scrolling region:
         z-index: 0;
       }
 
+      :host > ::content > app-header {
+        @apply(--layout-fixed-top);
+        z-index: 1;
+      }
+
       :host([has-scrolling-region]) {
         height: 100%;
       }
 
-      :host > ::content > app-header {
-        @apply(--layout-fixed-top);
-
-        z-index: 1;
-      }
-
       :host([has-scrolling-region]) > ::content > app-header {
         position: absolute;
+      }
+
+      :host([has-scrolling-region]) > #contentContainer {
+        @apply(--layout-fit);
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      :host([fullbleed]) {
+        @apply(--layout-vertical);
+        @apply(--layout-fit);
+      }
+
+      :host([fullbleed]) > #contentContainer {
+        @apply(--layout-vertical);
+        @apply(--layout-flex);
       }
 
       #contentContainer {
@@ -89,12 +112,6 @@ Using an own scrolling region:
         z-index: 0;
       }
 
-      :host([has-scrolling-region]) > #contentContainer {
-        @apply(--layout-fit);
-
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-      }
     </style>
 
     <content id="header" select="app-header"></content>
@@ -159,11 +176,9 @@ Using an own scrolling region:
         if (!this.isAttached || !header) {
           return;
         }
-
         // Get header height here so that style reads are batched together before style writes
         // (i.e. getBoundingClientRect() below).
         var headerHeight = header.offsetHeight;
-
         // Update the header position.
         if (!this.hasScrollingRegion) {
           var rect = this.getBoundingClientRect();
@@ -174,7 +189,6 @@ Using an own scrolling region:
           header.style.left = '';
           header.style.right = '';
         }
-
         // Update the content container position.
         var containerStyle = this.$.contentContainer.style;
         if (header.fixed && !header.willCondense() && this.hasScrollingRegion) {

--- a/app-header-layout/demo/footer.html
+++ b/app-header-layout/demo/footer.html
@@ -1,0 +1,90 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+  <title>app-header-layout demo</title>
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../../font-roboto/roboto.html">
+  <link rel="import" href="../../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../../paper-icon-button/paper-icon-button.html">
+  <link rel="import" href="../../app-header/app-header.html">
+  <link rel="import" href="../../app-scroll-effects/app-scroll-effects.html">
+  <link rel="import" href="../../app-toolbar/app-toolbar.html">
+  <link rel="import" href="../../demo/sample-content.html">
+  <link rel="import" href="../app-header-layout.html">
+
+  <style is="custom-style">
+
+    body {
+      margin: 0;
+      font-family: 'Roboto', 'Noto', sans-serif;
+      background-color: #eee;
+    }
+
+    app-header {
+      background-color: #4285f4;
+      color: #fff;
+    }
+
+    .content {
+      @apply(--layout-flex);
+    }
+
+    app-header paper-icon-button {
+      --paper-icon-button-ink-color: white;
+    }
+
+    footer {
+      height: 50px;
+      line-height: 50px;
+      text-align: center;
+      background-color: white;
+      font-size: 14px;
+    }
+
+  </style>
+
+</head>
+<body>
+
+  <!-- default to use body scroller -->
+  <app-header-layout fullbleed>
+
+    <app-header effects="waterfall" condenses reveals>
+      <app-toolbar>
+        <paper-icon-button icon="menu"></paper-icon-button>
+        <div main-title></div>
+        <paper-icon-button icon="search"></paper-icon-button>
+      </app-toolbar>
+      <app-toolbar></app-toolbar>
+      <app-toolbar>
+        <div spacer main-title>My Drive</div>
+      </app-toolbar>
+    </app-header>
+
+    <div class="content">
+      <!-- content goes here -->
+    </div>
+
+    <footer>
+      &copy; Polymer project
+    </footer>
+
+  </app-header-layout>
+
+</body>
+</html>

--- a/app-header-layout/demo/index.html
+++ b/app-header-layout/demo/index.html
@@ -34,6 +34,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <a href="simple.html">Simple Demo</a>
         <a href="scrolling-region.html">Scrolling Region</a>
         <a href="music.html">Music Demo</a>
+        <a href="footer.html">Adding a footer</a>
       </div>
     </div>
   </div>

--- a/app-header-layout/test/app-header-layout.html
+++ b/app-header-layout/test/app-header-layout.html
@@ -98,6 +98,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       });
 
+      test('fullbleed', function(done) {
+        headerLayout.setAttribute('fullbleed', '');
+        flush(function() {
+          assert.deepEqual(headerLayout.getBoundingClientRect(),
+              headerLayout.offsetParent.getBoundingClientRect());
+          done();
+        });
+      });
+
     });
 
   </script>

--- a/demo/demo6.html
+++ b/demo/demo6.html
@@ -70,6 +70,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <app-header-layout>
 
+    <app-header fixed effects="waterfall">
+      <app-toolbar>
+        <paper-icon-button id="toggle" icon="menu"></paper-icon-button>
+        <div main-title>Inbox</div>
+      </app-toolbar>
+    </app-header>
+
     <app-drawer-layout id="drawerLayout">
 
       <app-drawer>
@@ -101,13 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <sample-content size="100"></sample-content>
 
     </app-drawer-layout>
-
-    <app-header fixed effects="waterfall">
-      <app-toolbar>
-        <paper-icon-button id="toggle" icon="menu"></paper-icon-button>
-        <div main-title>Inbox</div>
-      </app-toolbar>
-    </app-header>
 
   </app-header-layout>
 

--- a/demo/demo7.html
+++ b/demo/demo7.html
@@ -51,9 +51,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body unresolved>
 
-  <app-drawer-layout>
+  <app-drawer-layout fullbleed>
 
-    <app-header-layout>
+    <app-header-layout fullbleed>
 
       <app-header fixed effects="waterfall">
         <app-toolbar>


### PR DESCRIPTION
The idea is to have a `fullbleed` attribute similar to app-drawer-layout.