### PR TITLE
Eliminate duplicate execution of _resetLayout in app-drawer-layout

### DIFF
--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -209,10 +209,6 @@ Custom property                          | Description                          
       },
 
       resetLayout: function() {
-        if (!this.isAttached) {
-          return;
-        }
-
         this.debounce('_resetLayout', function() {
           var drawer = this.drawer;
           var contentContainer = this.$.contentContainer;

--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -211,7 +211,6 @@ Custom property                  | Description                            | Defa
         position: {
           type: String,
           readOnly: true,
-          value: 'left',
           reflectToAttribute: true
         },
 
@@ -314,9 +313,7 @@ Custom property                  | Description                            | Defa
        * @method resetLayout
        */
       resetLayout: function() {
-        this.debounce('_resetLayout', function() {
-          this.fire('app-drawer-reset-layout');
-        }, 1);
+        this.fire('app-drawer-reset-layout');
       },
 
       _isRTL: function() {

--- a/app-drawer/test/app-drawer.html
+++ b/app-drawer/test/app-drawer.html
@@ -227,15 +227,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(drawer.getWidth(), contentContainer.offsetWidth);
       });
 
-      test('app-drawer-reset-layout', function(done) {
+      test('app-drawer-reset-layout', function() {
         var listenerSpy = sinon.spy();
         drawer.addEventListener('app-drawer-reset-layout', listenerSpy);
         drawer.align = 'right';
 
-        window.setTimeout(function() {
-          assert.isTrue(listenerSpy.called);
-          done();
-        }, 1);
+        assert.isTrue(listenerSpy.called);
       });
 
       test('app-drawer-transitioned', function(done) {


### PR DESCRIPTION
Before the debounced _resetLayout code in app-drawer-layout would be run twice (!) - this PR should fix it (tested by using console.log statements). Let’s talk about it before merging though, since I’ve tried to fix this a few times before and want to go over this to make sure it’s right