### PR TITLE
Fixes #31: link the drawer-toggle to app-drawer-layouts explicitly

### DIFF
--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -204,7 +204,10 @@ Custom property                          | Description                          
       _tapHandler: function(e) {
         var target = Polymer.dom(e).localTarget;
         if (target && target.hasAttribute('drawer-toggle')) {
-          this.drawer.toggle();
+          var hostClasses = this.hasAttribute('class') ? this.getAttribute('class').split() : false;
+          if (hostClasses && hostClasses.indexOf(target.getAttribute('drawer-toggle')) >= 0) {
+            this.drawer.toggle();
+          }
         }
       },
 


### PR DESCRIPTION
Fixes #31 by only toggling app-drawers with the class specified in the drawer-toggle attribute. This allows for a drawer-toggle to control specific drawers.