### PR TITLE
App grid docs

### DIFF
--- a/app-grid/README.md
+++ b/app-grid/README.md
@@ -2,20 +2,25 @@
 
 app-grid is a helper class useful for creating responsive, fluid grid layouts using custom properties.
 Because custom properties can be defined inside a `@media` rule, you can customize the grid layout
-for different breakpoints.
+for different responsive breakpoints.
 
 Example:
 
-Within an element definition, import `app-grid-style.html`, then include the style sheet in the style
-element inside the template.
+Import `app-grid-style.html` and include `app-grid-style` in the style of an element's definition.
+Then, add the class `app-grid` to a container such as `ul` or `div`:
 
 ```html
 <template>
-  <style include="app-grid-styles">
+  <style include="app-grid-style">
 
     :host {
       --app-grid-columns: 3;
       --app-grid-item-height: 100px;
+    }
+
+    ul {
+      padding: 0;
+      list-style: none;
     }
 
     .item {
@@ -29,12 +34,11 @@ element inside the template.
     }
 
   </style>
-
-  <div class="app-grid">
-    <div class="item">1</div>
-    <div class="item">2</div>
-    <div class="item">3</div>
-  </div>
+  <ul class="app-grid">
+    <li class="item">1</li>
+    <li class="item">2</li>
+    <li class="item">3</li>
+  </ul>
 </template>
 ```
 
@@ -45,35 +49,40 @@ smaller than 640px.
 
 In many cases, it's useful to expand an item more than 1 column. To achieve this type of layout,
 you can specify the number of columns the item should expand to by setting the custom property
-`--app-grid-expandible-item`. To indicate which item should expand, apply the mixin
+`--app-grid-expandible-item-columns`. To indicate which item should expand, apply the mixin
 `--app-grid-expandible-item` to a rule with a selector to the item. For example:
 
-```css
-<style>
+```html
+<template>
+  <style include="app-grid-style">
+    :host {
+      --app-grid-columns: 3;
+      --app-grid-item-height: 100px;
+      --app-grid-expandible-item-columns: 3;
+    }
 
-  :host {
-    --app-grid-columns: 3;
-    --app-grid-item-height: 100px;
-    --app-grid-expandible-item: 3;
-  }
+    ul {
+      padding: 0;
+      list-style: none;
+    }
 
-  /* Only the first item should expand */
-  .item:first-child {
-    @apply(--app-grid-expandible-item);
-  }
-
-</style>
+    /* Only the first item should expand */
+    .item:first-child {
+      @apply(--app-grid-expandible-item);
+    }
+  </style>
+</template>
 ```
 
 ### Preserving the aspect ratio
 
 When the size of a grid item should preserve the aspect ratio, you can add the `has-aspect-ratio`
-attribute to the element with the class `.app-grid`. Now, every item element becomes a wrapper around
+attribute to the element with the class `app-grid`. Now, every item element becomes a wrapper around
 the item content. For example:
 
-```css
+```html
 <template>
-  <style>
+  <style include="app-grid-style">
 
     :host {
       --app-grid-columns: 3;
@@ -81,22 +90,27 @@ the item content. For example:
       --app-grid-item-height: 50%;
     }
 
+    ul {
+      padding: 0;
+      list-style: none;
+    }
+
     .item {
       background-color: white;
     }
 
   </style>
-  <div has-aspect-ratio>
-    <div class="item">
+  <ul class="app-grid" has-aspect-ratio>
+    <li class="item">
       <div>item 1</div>
-    </div>
-    <div class="item">
+    </li>
+    <li class="item">
       <div>item 2</div>
-    </div>
-    <div class="item">
+    </li>
+    <li class="item">
       <div>item 3</div>
-    </div>
-  </div>
+    </li>
+  </ul>
 </template>
 ```
 

--- a/app-grid/app-grid-style.html
+++ b/app-grid/app-grid-style.html
@@ -10,6 +10,113 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../../polymer/polymer.html">
 
+<!--
+app-grid is a helper class useful for creating responsive, fluid grid layouts using custom properties.
+Because custom properties can be defined inside a `@media` rule, you can customize the grid layout
+for different responsive breakpoints.
+
+Example:
+
+Import `app-grid-style.html` and include `app-grid-style` in the style of an element's definition.
+Then, add the class `app-grid` to a container such as `ul` or `div`:
+
+```html
+<template>
+  <style include="app-grid-style">
+    :host {
+      --app-grid-columns: 3;
+      --app-grid-item-height: 100px;
+    }
+
+    ul {
+      padding: 0;
+      list-style: none;
+    }
+
+    .item {
+      background-color: white;
+    }
+  </style>
+  <ul class="app-grid">
+    <li class="item">1</li>
+    <li class="item">2</li>
+    <li class="item">3</li>
+  </ul>
+</template>
+```
+In the example above, the grid  will take 3 columns per row.
+
+### Expandible items
+
+In many cases, it's useful to expand an item more than 1 column. To achieve this type of layout,
+you can specify the number of columns the item should expand to by setting the custom property
+`--app-grid-expandible-item-columns`. To indicate which item should expand, apply the mixin
+`--app-grid-expandible-item` to a rule with a selector to the item. For example:
+
+<pre><code>
+&lt;template>
+  &lt;style include="app-grid-style">
+    :host {
+      --app-grid-columns: 3;
+      --app-grid-item-height: 100px;
+      --app-grid-expandible-item-columns: 3;
+    }
+
+    /* Only the first item should expand */
+    .item:first-child {
+      &#64;apply(--app-grid-expandible-item);
+    }
+  &lt;/style>
+&lt;/template>
+</code></pre>
+
+### Preserving the aspect ratio
+
+When the size of a grid item should preserve the aspect ratio, you can add the `has-aspect-ratio`
+attribute to the element with the class `.app-grid`. Now, every item element becomes a wrapper around
+the item content. For example:
+
+```html
+<template>
+  <style include="app-grid-style">
+    :host {
+      --app-grid-columns: 3;
+      /* 50% the width of the item is equivalent to 2:1 aspect ratio*/
+      --app-grid-item-height: 50%;
+    }
+
+    .item {
+      background-color: white;
+    }
+  </style>
+  <ul class="app-grid" has-aspect-ratio>
+    <li class="item">
+      <div>item 1</div>
+    </li>
+    <li class="item">
+      <div>item 2</div>
+    </li>
+    <li class="item">
+      <div>item 3</div>
+    </li>
+  </ul>
+</template>
+```
+
+### Styling
+
+Custom property                               | Description                                                | Default
+----------------------------------------------|------------------------------------------------------------|------------------
+`--app-grid-columns`                          | The number of columns per row.                             | 1
+`--app-grid-gutter`                           | The space between two items.                               | 0px
+`--app-grid-item-height`                      | The height of the items.                                   | auto
+`--app-grid-expandible-item-columns`          | The number of columns an expandible item should expand to. | 1
+
+@group App Elements
+@pseudoElement app-grid
+@demo app-grid/demo/index.html
+-->
+
 <dom-module id="app-grid-style">
   <template>
     <style>
@@ -62,7 +169,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         max-width: calc((100% - 0.1px - (var(--app-grid-gutter, 0px) * var(--app-grid-columns, 1))) / var(--app-grid-columns, 1));
         margin-bottom: var(--app-grid-gutter, 0px);
         margin-right: var(--app-grid-gutter, 0px);
-        height: var(--app-grid-item-height, auto);
+        height: var(--app-grid-item-height);
         box-sizing: border-box;
       }
 

--- a/app-grid/demo/aspect-ratio.html
+++ b/app-grid/demo/aspect-ratio.html
@@ -51,7 +51,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         ul {
-          margin: 0;
           padding: 0;
           list-style: none;
         }

--- a/app-grid/demo/flickr-grid-layout.html
+++ b/app-grid/demo/flickr-grid-layout.html
@@ -62,7 +62,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         ul {
-          margin: 0;
           padding: 0;
           list-style: none;
         }

--- a/app-grid/demo/md-grid-layout.html
+++ b/app-grid/demo/md-grid-layout.html
@@ -50,7 +50,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           display: block;
           --app-grid-columns: 4;
           --app-grid-gutter: 10px;
-          --app-grid-item-height: 250px;
           --app-grid-expandible-item-columns: 4;
           --paper-icon-button-ink-color: white;
         }
@@ -61,7 +60,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         ul {
-          margin: 0;
           padding: 0;
           list-style: none;
         }
@@ -73,14 +71,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         .item {
+          height: 250px;
           position: relative;
           background-color: white;
-          background-image: url();
           background-size: cover;
           background-position: center center;
         }
 
         .item:nth-child(5n + 1) {
+          height: 30vmax;
           @apply(--app-grid-expandible-item);
         }
 

--- a/app-grid/demo/simple-responsive-grid.html
+++ b/app-grid/demo/simple-responsive-grid.html
@@ -44,7 +44,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         }
 
         ul {
-          margin: 0;
           padding: 0;
           list-style: none;
         }

--- a/app-layout.html
+++ b/app-layout.html
@@ -11,6 +11,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="helpers/helpers.html">
 <link rel="import" href="app-drawer/app-drawer.html">
 <link rel="import" href="app-drawer-layout/app-drawer-layout.html">
+<link rel="import" href="app-grid/app-grid-style.html">
 <link rel="import" href="app-header/app-header.html">
 <link rel="import" href="app-header-layout/app-header-layout.html">
 <link rel="import" href="app-scrollpos-control/app-scrollpos-control.html">


### PR DESCRIPTION
Fixes a few mistakes in the docs and adds the annotations for app-grid, so it can appear in the catalog.