### PR TITLE
Use empty function instead of Function()

### DIFF
--- a/app-scroll-effects/app-scroll-effects-behavior.html
+++ b/app-scroll-effects/app-scroll-effects-behavior.html
@@ -280,7 +280,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       var startsAt = parseFloat(effectsConfig.startsAt || 0);
       var endsAt = parseFloat(effectsConfig.endsAt || 1);
       var deltaS = endsAt - startsAt;
-      var noop = Function();
+      var noop = function() {};
       // fast path if possible
       var runFn = (startsAt === 0 && endsAt === 1) ? effectDef.run :
         function(progress, y) {


### PR DESCRIPTION
Function() triggers a complaint in Chrome Apps about
unsafe-eval. This commit replaces the noop behavior with an
empty function to circumvent this warning while retaining the
same functionality.

Closes #286