### PR TITLE
Add transitionDuration property to app-drawer

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -63,7 +63,7 @@ Custom property                  | Description                            | Defa
 
         visibility: hidden;
 
-        transition: visibility 0.2s ease;
+        transition-property: visibility;
       }
 
       :host([opened]) {
@@ -91,9 +91,10 @@ Custom property                  | Description                            | Defa
         width: var(--app-drawer-width, 256px);
         padding: 120px 0;
 
-        transition: 0.2s ease;
         transition-property: -webkit-transform;
         transition-property: transform;
+        transition-duration: inherit;
+        transition-timing-function: inherit;
         -webkit-transform: translate3d(-100%, 0, 0);
         transform: translate3d(-100%, 0, 0);
 
@@ -140,7 +141,9 @@ Custom property                  | Description                            | Defa
         bottom: 0;
         left: 0;
 
-        transition: opacity 0.2s ease;
+        transition-property: opacity;
+        transition-duration: inherit;
+        transition-timing-function: inherit;
         -webkit-transform: translateZ(0);
         transform:  translateZ(0);
 
@@ -196,6 +199,15 @@ Custom property                  | Description                            | Defa
         },
 
         /**
+         * The transition duration of the drawer in milliseconds.
+         */
+        transitionDuration: {
+          type: Number,
+          value: 200,
+          observer: '_transitionDurationChanged'
+        },
+
+        /**
          * The alignment of the drawer on the screen ('left', 'right', 'start' or 'end').
          * 'start' computes to left and 'end' to right in LTR layout and vice versa in RTL
          * layout.
@@ -234,7 +246,8 @@ Custom property                  | Description                            | Defa
 
       observers: [
         'resetLayout(position, isAttached)',
-        '_resetPosition(align, isAttached)'
+        '_resetPosition(align, isAttached)',
+        '_openedPersistentChanged(opened, persistent)'
       ],
 
       _translateOffset: 0,
@@ -249,21 +262,21 @@ Custom property                  | Description                            | Defa
 
       _lastTabStop: null,
 
-      ready: function() {
-        // Only transition the drawer after its first render (e.g. app-drawer-layout
-        // may need to set the initial opened state which should not be transitioned).
-        this._setTransitionDuration('0s');
-      },
-
       attached: function() {
         // Only transition the drawer after its first render (e.g. app-drawer-layout
         // may need to set the initial opened state which should not be transitioned).
+        this.style.transitionDuration = '';
         Polymer.RenderStatus.afterNextRender(this, function() {
-          this._setTransitionDuration('');
+          this.style.transitionDuration = this.transitionDuration + 'ms';
           this._boundEscKeydownHandler = this._escKeydownHandler.bind(this);
           this._resetDrawerState();
 
-          this.addEventListener('transitionend', this._transitionend.bind(this));
+          // contentContainer will transition on opened state changed, and scrim will
+          // transition on persistent state changed when opened - these are the
+          // transitions we are interested in.
+          this.$.scrim.addEventListener('transitionend', this._transitionend.bind(this));
+          this.$.contentContainer.addEventListener('transitionend', this._transitionend.bind(this));
+
           this.addEventListener('keydown', this._tabKeydownHandler.bind(this))
 
           // Only listen for horizontal track so you can vertically scroll inside the drawer.
@@ -366,7 +379,7 @@ Custom property                  | Description                            | Defa
         this._drawerState = this._DRAWER_STATE.TRACKING;
 
         // Disable transitions since style attributes will reflect user track events.
-        this._setTransitionDuration('0s');
+        this.style.transitionDuration = '';
         this.style.visibility = 'visible';
 
         var rect = this.$.contentContainer.getBoundingClientRect();
@@ -417,12 +430,12 @@ Custom property                  | Description                            | Defa
           this.opened = this.position === 'left';
         }
 
-        // Trigger app-drawer-transitioned now since there will be no transitionend event.
         if (isInEndState) {
+          // Reset drawer state now since there will be no transitionend event.
           this._resetDrawerState();
         }
 
-        this._setTransitionDuration('');
+        this.style.transitionDuration = this.transitionDuration + 'ms';
         this._resetDrawerTranslate();
         this.style.visibility = '';
       },
@@ -491,38 +504,21 @@ Custom property                  | Description                            | Defa
 
         // Calculate the amount of time needed to finish the transition based on the
         // initial slope of the timing function.
-        this._setTransitionDuration((this._FLING_INITIAL_SLOPE * dx / velocity) + 'ms');
-        this._setTransitionTimingFunction(this._FLING_TIMING_FUNCTION);
+        this.style.transitionDuration = this._FLING_INITIAL_SLOPE * dx / velocity + 'ms';
+        this.style.transitionTimingFunction = this._FLING_TIMING_FUNCTION;
 
         this._resetDrawerTranslate();
       },
 
-      _transitionend: function(event) {
-        // contentContainer will transition on opened state changed, and scrim will
-        // transition on persistent state changed when opened - these are the
-        // transitions we are interested in.
-        var target = Polymer.dom(event).rootTarget;
-        if (target === this.$.contentContainer || target === this.$.scrim) {
-
-          // If the drawer was flinging, we need to reset the style attributes.
-          if (this._drawerState === this._DRAWER_STATE.FLINGING) {
-            this._setTransitionDuration('');
-            this._setTransitionTimingFunction('');
-            this.style.visibility = '';
-          }
-
-          this._resetDrawerState();
+      _transitionend: function() {
+        // If the drawer was flinging, we need to reset the style attributes.
+        if (this._drawerState === this._DRAWER_STATE.FLINGING) {
+          this.style.transitionDuration = this.transitionDuration + 'ms';
+          this.style.transitionTimingFunction = '';
+          this.style.visibility = '';
         }
-      },
 
-      _setTransitionDuration: function(duration) {
-        this.$.contentContainer.style.transitionDuration = duration;
-        this.$.scrim.style.transitionDuration = duration;
-      },
-
-      _setTransitionTimingFunction: function(timingFunction) {
-        this.$.contentContainer.style.transitionTimingFunction = timingFunction;
-        this.$.scrim.style.transitionTimingFunction = timingFunction;
+        this._resetDrawerState();
       },
 
       _translateDrawer: function(x) {
@@ -628,6 +624,17 @@ Custom property                  | Description                            | Defa
               this._firstTabStop.focus();
             }
           }
+        }
+      },
+
+      _transitionDurationChanged: function(duration) {
+        this.style.transitionDuration = duration + 'ms';
+      },
+
+      _openedPersistentChanged: function() {
+        if (this.transitionDuration === 0) {
+          // Reset drawer state now since there will be no transitionend event.
+          this._resetDrawerState();
         }
       },
 

--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -93,8 +93,6 @@ Custom property                  | Description                            | Defa
 
         transition-property: -webkit-transform;
         transition-property: transform;
-        transition-duration: inherit;
-        transition-timing-function: inherit;
         -webkit-transform: translate3d(-100%, 0, 0);
         transform: translate3d(-100%, 0, 0);
 
@@ -142,8 +140,6 @@ Custom property                  | Description                            | Defa
         left: 0;
 
         transition-property: opacity;
-        transition-duration: inherit;
-        transition-timing-function: inherit;
         -webkit-transform: translateZ(0);
         transform:  translateZ(0);
 
@@ -203,8 +199,7 @@ Custom property                  | Description                            | Defa
          */
         transitionDuration: {
           type: Number,
-          value: 200,
-          observer: '_transitionDurationChanged'
+          value: 200
         },
 
         /**
@@ -247,6 +242,7 @@ Custom property                  | Description                            | Defa
       observers: [
         'resetLayout(position, isAttached)',
         '_resetPosition(align, isAttached)',
+        '_styleTransitionDuration(transitionDuration)',
         '_openedPersistentChanged(opened, persistent)'
       ],
 
@@ -265,9 +261,9 @@ Custom property                  | Description                            | Defa
       attached: function() {
         // Only transition the drawer after its first render (e.g. app-drawer-layout
         // may need to set the initial opened state which should not be transitioned).
-        this.style.transitionDuration = '';
+        this._styleTransitionDuration(0);
         Polymer.RenderStatus.afterNextRender(this, function() {
-          this.style.transitionDuration = this.transitionDuration + 'ms';
+          this._styleTransitionDuration(this.transitionDuration);
           this._boundEscKeydownHandler = this._escKeydownHandler.bind(this);
           this._resetDrawerState();
 
@@ -379,7 +375,7 @@ Custom property                  | Description                            | Defa
         this._drawerState = this._DRAWER_STATE.TRACKING;
 
         // Disable transitions since style attributes will reflect user track events.
-        this.style.transitionDuration = '';
+        this._styleTransitionDuration(0);
         this.style.visibility = 'visible';
 
         var rect = this.$.contentContainer.getBoundingClientRect();
@@ -435,7 +431,7 @@ Custom property                  | Description                            | Defa
           this._resetDrawerState();
         }
 
-        this.style.transitionDuration = this.transitionDuration + 'ms';
+        this._styleTransitionDuration(this.transitionDuration);
         this._resetDrawerTranslate();
         this.style.visibility = '';
       },
@@ -504,8 +500,8 @@ Custom property                  | Description                            | Defa
 
         // Calculate the amount of time needed to finish the transition based on the
         // initial slope of the timing function.
-        this.style.transitionDuration = this._FLING_INITIAL_SLOPE * dx / velocity + 'ms';
-        this.style.transitionTimingFunction = this._FLING_TIMING_FUNCTION;
+        this._styleTransitionDuration(this._FLING_INITIAL_SLOPE * dx / velocity);
+        this._styleTransitionTimingFunction(this._FLING_TIMING_FUNCTION);
 
         this._resetDrawerTranslate();
       },
@@ -513,12 +509,23 @@ Custom property                  | Description                            | Defa
       _transitionend: function() {
         // If the drawer was flinging, we need to reset the style attributes.
         if (this._drawerState === this._DRAWER_STATE.FLINGING) {
-          this.style.transitionDuration = this.transitionDuration + 'ms';
-          this.style.transitionTimingFunction = '';
+          this._styleTransitionDuration(this.transitionDuration);
+          this._styleTransitionTimingFunction('');
           this.style.visibility = '';
         }
 
         this._resetDrawerState();
+      },
+
+      _styleTransitionDuration: function(duration) {
+        this.style.transitionDuration = duration + 'ms';
+        this.$.contentContainer.style.transitionDuration = duration + 'ms';
+        this.$.scrim.style.transitionDuration = duration + 'ms';
+      },
+
+      _styleTransitionTimingFunction: function(timingFunction) {
+        this.$.contentContainer.style.transitionTimingFunction = timingFunction;
+        this.$.scrim.style.transitionTimingFunction = timingFunction;
       },
 
       _translateDrawer: function(x) {
@@ -625,10 +632,6 @@ Custom property                  | Description                            | Defa
             }
           }
         }
-      },
-
-      _transitionDurationChanged: function(duration) {
-        this.style.transitionDuration = duration + 'ms';
       },
 
       _openedPersistentChanged: function() {

--- a/app-drawer/test/app-drawer.html
+++ b/app-drawer/test/app-drawer.html
@@ -17,6 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../../web-component-tester/browser.js"></script>
   <script src="../../../test-fixture/test-fixture-mocha.js"></script>
+  <link rel="import" href="../../../polymer/polymer.html">
   <link rel="import" href="../../../test-fixture/test-fixture.html">
   <link rel="import" href="../app-drawer.html">
   <style is="custom-style">
@@ -111,25 +112,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('default values', function() {
         assert.isFalse(drawer.opened);
         assert.isFalse(drawer.persistent);
+        assert.equal(drawer.transitionDuration, 200);
         assert.equal(drawer.align, 'left');
         assert.isFalse(drawer.swipeOpen);
         assert.isFalse(drawer.noFocusTrap);
       });
 
       test('set scroll direction', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           assert.equal(drawer['__polymerGesturesTouchAction'], 'pan-y');
           done();
-        }, 350);
+        });
+      });
+
+      test('transitionDuration property', function(done) {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          assertTransitionDuration('200ms');
+
+          drawer.transitionDuration = 10;
+
+          assertTransitionDuration('10ms');
+          done();
+        });
       });
 
       test('transitions are enabled after attached', function(done) {
-        assertTransitionDuration('0s');
+        assertTransitionDuration('0ms');
 
-        window.setTimeout(function() {
-          assertTransitionDuration('');
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          assertTransitionDuration('200ms');
           done();
-        }, 350);
+        });
       });
 
       test('computed position', function() {
@@ -238,6 +251,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('app-drawer-transitioned', function(done) {
         window.setTimeout(function() {
           var listenerSpy = sinon.spy();
+          drawer.transitionDuration = 1;
           drawer.addEventListener('app-drawer-transitioned', listenerSpy);
           drawer.persistent = true;
 
@@ -289,60 +303,104 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                       assert.equal(listenerSpy.callCount, 6,
                         'should fire after swiping beyond end state');
                       done();
-                    }, 350);
-                  }, 350);
-                }, 350);
-              }, 350);
-            }, 350);
-          }, 350);
+                    }, 150);
+                  }, 150);
+                }, 150);
+              }, 150);
+            }, 150);
+          }, 150);
         }, 100);
       });
 
+      test('app-drawer-transitioned when transitionDuration is 0', function(done) {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          var listenerSpy = sinon.spy();
+          drawer.transitionDuration = 0;
+          drawer.addEventListener('app-drawer-transitioned', listenerSpy);
+          drawer.persistent = true;
+
+          assert.isFalse(listenerSpy.called,
+            'should not fire after toggling persistent when closed');
+
+          drawer.opened = true;
+
+          assert.equal(listenerSpy.callCount, 1, 'should fire after toggling opened state');
+
+          drawer.persistent = false;
+
+          assert.equal(listenerSpy.callCount, 2,
+            'should fire after toggling persistent when opened');
+
+          drawer.fire('track', { state: 'start' });
+          drawer.fire('track', { state: 'track', dx: 0, ddx: 0 });
+          drawer.fire('track', { state: 'end', dx: -200, ddx: -200 });
+
+          assert.isFalse(drawer.opened);
+          assert.equal(listenerSpy.callCount, 3, 'should fire after flinging');
+            
+          drawer.fire('track', { state: 'start' });
+          drawer.fire('track', { state: 'track', dx: 200, ddx: 200 });
+          drawer.fire('track', { state: 'end', dx: 200, ddx: 0 });
+
+          assert.isTrue(drawer.opened);
+          assert.equal(listenerSpy.callCount, 4, 'should fire after swiping');
+
+          drawer.fire('track', { state: 'start' });
+          drawer.fire('track', { state: 'track', dx: -1000, ddx: -1000 });
+          drawer.fire('track', { state: 'end', dx: -1000, ddx: 0 });
+
+          assert.isFalse(drawer.opened);
+          assert.equal(listenerSpy.callCount, 5,
+            'should fire after swiping beyond end state');
+          done();
+        });
+      });
+
       test('track events block user selection', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           var ev = drawer.fire('track', null /* detail */, { cancelable: true });
 
           assert.isTrue(ev.defaultPrevented);
           done();
-        }, 350);
+        });
       });
 
       test('styles reset after swiping', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.fire('track', { state: 'start' });
 
           assert.equal(drawer.style.visibility, 'visible');
-          assertTransitionDuration('0s');
+          assertTransitionDuration('0ms');
 
           drawer.fire('track', { state: 'track', dx: 200, ddx: 200 });
           drawer.fire('track', { state: 'end', dx: 200, ddx: 0 });
 
           assert.equal(drawer.style.visibility, '');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('styles reset after swiping beyond the end state', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.fire('track', { state: 'start' });
 
           assert.equal(drawer.style.visibility, 'visible');
-          assertTransitionDuration('0s');
+          assertTransitionDuration('0ms');
 
           drawer.fire('track', { state: 'track', dx: 1000, ddx: 1000 });
           drawer.fire('track', { state: 'end', dx: 1000, ddx: 0 });
 
           assert.equal(drawer.style.visibility, '');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('left drawer swiping', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           var drawerWidth = drawer.getWidth();
           var halfWidth = drawerWidth / 2;
           drawer.align = 'left';
@@ -383,11 +441,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           assert.isFalse(drawer.opened, 'drawer closes when track distance is large');
           done();
-        }, 350);
+        });
       });
 
       test('right drawer swiping', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           var drawerWidth = drawer.getWidth();
           var halfWidth = drawerWidth / 2;
           drawer.align = 'right';
@@ -428,56 +486,56 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           assert.isFalse(drawer.opened, 'drawer closes when track distance is large');
           done();
-        }, 350);
+        });
       });
 
       test('styles reset after flinging', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.fire('track', { state: 'start' });
 
           assert.equal(drawer.style.visibility, 'visible');
-          assertTransitionDuration('0s');
+          assertTransitionDuration('0ms');
 
           drawer.fire('track', { state: 'track', dx: 0, ddx: 0 });
           drawer.fire('track', { state: 'end', dx: 200, ddx: 200 });
 
           window.setTimeout(function() {
             assert.equal(drawer.style.visibility, '');
-            assertTransitionDuration('');
+            assertTransitionDuration('200ms');
             assertTransitionTimingFunction('');
             assertDrawerStylesReset();
             done();
-          }, 350);
-        }, 350);
+          }, 150);
+        });
       });
 
       test('styles reset after flinging beyond the end state', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.fire('track', { state: 'start' });
 
           assert.equal(drawer.style.visibility, 'visible');
-          assertTransitionDuration('0s');
+          assertTransitionDuration('0ms');
 
           drawer.fire('track', { state: 'track', dx: 0, ddx: 0 });
           drawer.fire('track', { state: 'end', dx: 1000, ddx: 1000 });
 
           assert.equal(drawer.style.visibility, '');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertTransitionTimingFunction('');
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('left drawer flinging open', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.align = 'left';
           drawer.fire('track', { state: 'start' });
           drawer.fire('track', { state: 'track', dx: 0, ddx: 0 });
           drawer.fire('track', { state: 'end', dx: 0.1, ddx: 0.1 });
 
           assert.isFalse(drawer.opened, 'drawer stays closed when velocity is small');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertTransitionTimingFunction('');
           assertDrawerStylesReset();
 
@@ -490,11 +548,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertTransitionTimingFunction(drawer._FLING_TIMING_FUNCTION);
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('left drawer flinging close', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.align = 'left';
           drawer.opened = true;
           drawer.fire('track', { state: 'start' });
@@ -502,7 +560,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           drawer.fire('track', { state: 'end', dx: -0.1, ddx: -0.1 });
 
           assert.isTrue(drawer.opened, 'drawer stays opened when velocity is small');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertTransitionTimingFunction('');
           assertDrawerStylesReset();
 
@@ -515,18 +573,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertTransitionTimingFunction(drawer._FLING_TIMING_FUNCTION);
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('right drawer flinging open', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.align = 'right';
           drawer.fire('track', { state: 'start' });
           drawer.fire('track', { state: 'track', dx: 0, ddx: 0 });
           drawer.fire('track', { state: 'end', dx: -0.1, ddx: -0.1 });
 
           assert.isFalse(drawer.opened, 'drawer stays closed when velocity is small');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertTransitionTimingFunction('');
           assertDrawerStylesReset();
 
@@ -539,11 +597,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertTransitionTimingFunction(drawer._FLING_TIMING_FUNCTION);
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
       test('right drawer flinging close', function(done) {
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
           drawer.align = 'right';
           drawer.opened = true;
           drawer.fire('track', { state: 'start' });
@@ -551,7 +609,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           drawer.fire('track', { state: 'end', dx: 0.1, ddx: 0.1 });
 
           assert.isTrue(drawer.opened, 'drawer stays opened when velocity is small');
-          assertTransitionDuration('');
+          assertTransitionDuration('200ms');
           assertTransitionTimingFunction('');
           assertDrawerStylesReset();
 
@@ -564,40 +622,30 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assertTransitionTimingFunction(drawer._FLING_TIMING_FUNCTION);
           assertDrawerStylesReset();
           done();
-        }, 350);
+        });
       });
 
-      test('doc scroll', function(done) {
-        window.setTimeout(function() {
-          drawer.opened = true;
+      test('doc scroll', function() {
+        drawer.transitionDuration = 0;
+        drawer.opened = true;
 
-          window.setTimeout(function() {
-            assert.equal(document.body.style.overflow, 'hidden',
-              'should block scrolling when opened');
+        assert.equal(document.body.style.overflow, 'hidden',
+          'should block scrolling when opened');
 
-            drawer.persistent = true;
+        drawer.persistent = true;
 
-            window.setTimeout(function() {
-              assert.equal(document.body.style.overflow, '',
-                'should not block scrolling when persistent');
+        assert.equal(document.body.style.overflow, '',
+          'should not block scrolling when persistent');
 
-              drawer.persistent = false;
+        drawer.persistent = false;
 
-              window.setTimeout(function() {
-                assert.equal(document.body.style.overflow, 'hidden',
-                  'should block scrolling when not persistent');
+        assert.equal(document.body.style.overflow, 'hidden',
+          'should block scrolling when not persistent');
 
-                drawer.opened = false;
+        drawer.opened = false;
 
-                window.setTimeout(function() {
-                  assert.equal(document.body.style.overflow, '',
-                    'should not block scrolling when closed');
-                  done();
-                }, 350);
-              }, 350);
-            }, 350);
-          }, 350);
-        }, 100);
+        assert.equal(document.body.style.overflow, '',
+          'should not block scrolling when closed');
       });
 
       test('focus trap', function(done) {
@@ -608,9 +656,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var div = Polymer.dom(drawer).querySelector('div[tabindex]');
         var inputFocusSpy = sinon.spy(input, 'focus');
         var divFocusSpy = sinon.spy(div, 'focus');
-        drawer.opened = true;
 
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          drawer.transitionDuration = 0;
+          drawer.opened = true;
+
           assert.isTrue(inputFocusSpy.called);
 
           var e = fireKeydownEvent(input, 9);
@@ -634,7 +684,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.isTrue(inputFocusSpy.called);
           assert.isTrue(e.defaultPrevented, 'should prevent default');
           done();
-        }, 350);
+        });
       });
 
       test('focus trap with app-drawer tabindex set', function(done) {
@@ -644,14 +694,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var input = Polymer.dom(drawer).querySelector('input');
         var drawerFocusSpy = sinon.spy(drawer, 'focus');
         var inputFocusSpy = sinon.spy(input, 'focus');
-        drawer.tabIndex = 0;
-        drawer.opened = true;
 
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          drawer.transitionDuration = 0;
+          drawer.tabIndex = 0;
+          drawer.opened = true;
+
           assert.isTrue(drawerFocusSpy.called);
           assert.isFalse(inputFocusSpy.called);
           done();
-        }, 350);
+        });
       });
 
       test('no focus trap', function(done) {
@@ -660,29 +712,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var drawer = root.querySelector('app-drawer');
         var input = Polymer.dom(drawer).querySelector('input');
         var inputFocusSpy = sinon.spy(input, 'focus');
-        drawer.noFocusTrap = true;
-        drawer.opened = true;
   
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          drawer.transitionDuration = 0;
+          drawer.noFocusTrap = true;
+          drawer.opened = true;
+
           assert.isFalse(inputFocusSpy.called);
           done();
-        }, 350);
+        });
       });
 
       test('esc key handler', function(done) {
-        drawer.opened = true;
-
-        window.setTimeout(function() {
+        Polymer.RenderStatus.afterNextRender(drawer, function() {
+          drawer.transitionDuration = 0;
+          drawer.opened = true;
           var e = fireKeydownEvent(document, 27);
 
           assert.isFalse(drawer.opened, 'should close drawer on esc');
           assert.isTrue(e.defaultPrevented, 'should prevent default');
           done();
-        }, 350);
+        });
       });
 
       test('scrim', function() {
-        scrim.style.transitionDuration = '0s';
+        drawer.transitionDuration = 0;
 
         assert.equal(window.getComputedStyle(scrim)['opacity'], 0);
 


### PR DESCRIPTION
This allows you to disable transitions (by setting `transitionDuration` to 0). This is a property instead of a CSS custom property because we need to read its value to see if it's 0 - if it is, there won't be a `transitionend` event and we call the `_resetDrawerState` method directly. (An alternative would have been to use `getComputedStyle()`, but that would be expensive.)

cc @frankiefu @blasten 