### PR TITLE
app-drawer/-layout: Use `click` instead of tap; assignedNodes

### DIFF
--- a/app-drawer-layout/README.md
+++ b/app-drawer-layout/README.md
@@ -52,7 +52,7 @@ With an app-header-layout:
 </app-drawer-layout>
 ```
 
-Add the `drawer-toggle` attribute to elements inside `app-drawer-layout` that toggle the drawer on tap events:
+Add the `drawer-toggle` attribute to elements inside `app-drawer-layout` that toggle the drawer on click events:
 
 ```html
 <app-drawer-layout>

--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -65,7 +65,7 @@ With an app-header-layout:
 </app-drawer-layout>
 ```
 
-Add the `drawer-toggle` attribute to elements inside `app-drawer-layout` that toggle the drawer on tap events:
+Add the `drawer-toggle` attribute to elements inside `app-drawer-layout` that toggle the drawer on click events:
 
 ```html
 <app-drawer-layout>
@@ -136,8 +136,8 @@ Custom property                          | Description                          
       <slot></slot>
     </div>
 
-    <content select="[slot=drawer]"></content>
-    <slot name="drawer"></slot>
+    <content id="drawerContent" select="[slot=drawer]"></content>
+    <slot id="drawerSlot" name="drawer"></slot>
 
     <iron-media-query
         query="[[_computeMediaQuery(forceNarrow, responsiveWidth)]]"
@@ -190,7 +190,7 @@ Custom property                          | Description                          
       },
 
       listeners: {
-        'tap': '_tapHandler',
+        'click': '_clickHandler',
         'app-drawer-attached': '_resetDrawerState',
         'app-drawer-reset-layout': 'resetLayout',
         'iron-resize': 'resetLayout'
@@ -207,10 +207,12 @@ Custom property                          | Description                          
        * @property drawer
        */
       get drawer() {
-        return Polymer.dom(this).querySelector('[slot=drawer]');
+        return Polymer.Element ?
+            Polymer.dom(this.$.drawerSlot).assignedNodes({ flatten: true })[0] :
+            Polymer.dom(this.$.drawerContent).getDistributedNodes()[0];
       },
 
-      _tapHandler: function(e) {
+      _clickHandler: function(e) {
         var target = Polymer.dom(e).localTarget;
         if (target && target.hasAttribute('drawer-toggle')) {
           var drawer = this.drawer;

--- a/app-drawer-layout/demo/index.html
+++ b/app-drawer-layout/demo/index.html
@@ -19,8 +19,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../../font-roboto/roboto.html">
-  <!-- <link rel="import" href="../../../iron-icons/iron-icons.html"> -->
-  <!-- <link rel="import" href="../../../paper-icon-button/paper-icon-button.html"> -->
+  <link rel="import" href="../../../iron-icons/iron-icons.html">
+  <link rel="import" href="../../../paper-icon-button/paper-icon-button.html">
   <link rel="import" href="../../demo/sample-content.html">
   <link rel="import" href="../../app-toolbar/app-toolbar.html">
   <link rel="import" href="../../app-drawer/app-drawer.html">
@@ -39,6 +39,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: #fff;
     }
 
+    [hidden] {
+      display: none;
+    }
+
     app-drawer {
       --app-drawer-width: 350px;
       --app-drawer-content-container: {
@@ -51,17 +55,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <app-drawer-layout>
+  <dom-bind>
+    <template is="dom-bind">
 
-    <app-drawer slot="drawer"></app-drawer>
+      <app-drawer-layout narrow="{{narrow}}">
 
-    <app-toolbar>
-      <paper-icon-button icon="menu" drawer-toggle></paper-icon-button>
-    </app-toolbar>
+        <app-drawer slot="drawer"></app-drawer>
 
-    <sample-content size="100"></sample-content>
+        <app-toolbar>
+          <paper-icon-button icon="menu" drawer-toggle hidden$="[[!narrow]]"></paper-icon-button>
+        </app-toolbar>
 
-  </app-drawer-layout>
+        <sample-content size="100"></sample-content>
+
+      </app-drawer-layout>
+
+    </template>
+  </dom-bind>
 
 </body>
 </html>

--- a/app-drawer-layout/test/app-drawer-layout.html
+++ b/app-drawer-layout/test/app-drawer-layout.html
@@ -81,6 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       setup(function() {
         drawerLayout = fixture('testDrawerLayout');
         drawer = drawerLayout.querySelector('app-drawer');
+        Polymer.dom.flush();
       });
 
       test('default values', function() {
@@ -208,8 +209,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.doesNotThrow(function() {
           drawerLayout = document.body.appendChild(document.createElement('app-drawer-layout'));
         });
-        assert.isUndefined(drawerLayout.drawer);
         Polymer.dom.flush();
+
+        assert.isUndefined(drawerLayout.drawer);
         assert.equal(drawerLayout.$.contentContainer.style.marginLeft, '');
         assert.equal(drawerLayout.$.contentContainer.style.marginRight, '');
 

--- a/app-drawer-layout/test/app-drawer-layout.html
+++ b/app-drawer-layout/test/app-drawer-layout.html
@@ -129,18 +129,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         assert.isFalse(drawer.opened);
 
-        Polymer.Base.fire('tap', null /* detail */, { node: drawerLayout.querySelector('p') });
+        Polymer.Base.fire('click', null /* detail */, { node: drawerLayout.querySelector('p') });
 
         assert.isFalse(drawer.opened);
 
-        Polymer.Base.fire('tap', null /* detail */, { node: drawerLayout.querySelector('[drawer-toggle]') });
+        Polymer.Base.fire('click', null /* detail */, { node: drawerLayout.querySelector('[drawer-toggle]') });
 
         assert.isTrue(drawer.opened);
 
         drawerLayout.responsiveWidth = '0px';
 
         window.setTimeout(function() {
-          Polymer.Base.fire('tap', null /* detail */, { node: drawerLayout.querySelector('[drawer-toggle]') });
+          Polymer.Base.fire('click', null /* detail */, { node: drawerLayout.querySelector('[drawer-toggle]') });
 
           assert.isTrue(drawer.opened);
 
@@ -208,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.doesNotThrow(function() {
           drawerLayout = document.body.appendChild(document.createElement('app-drawer-layout'));
         });
-        assert.isNull(drawerLayout.drawer);
+        assert.isUndefined(drawerLayout.drawer);
         Polymer.dom.flush();
         assert.equal(drawerLayout.$.contentContainer.style.marginLeft, '');
         assert.equal(drawerLayout.$.contentContainer.style.marginRight, '');

--- a/app-drawer-layout/test/index.html
+++ b/app-drawer-layout/test/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'app-drawer-layout.html',
-      'app-drawer-layout.html?dom=shadow'
+      'app-drawer-layout.html?wc-shadydom=true'
     ]);
   </script>
 </body>

--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -162,7 +162,7 @@ Custom property                  | Description                            | Defa
       }
     </style>
 
-    <div id="scrim" on-tap="close"></div>
+    <div id="scrim" on-click="close"></div>
 
     <div id="contentContainer">
       <content select=":not([slot])"></content>

--- a/app-drawer/demo/left-drawer.html
+++ b/app-drawer/demo/left-drawer.html
@@ -61,7 +61,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     var drawer = document.querySelector('app-drawer');
-    document.querySelector('paper-icon-button').addEventListener('tap', function() {
+    document.querySelector('paper-icon-button').addEventListener('click', function() {
       drawer.toggle();
     });
   </script>

--- a/app-drawer/demo/right-drawer.html
+++ b/app-drawer/demo/right-drawer.html
@@ -60,7 +60,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <app-toolbar>
         <div main-title></div>
-        <paper-icon-button icon="menu" on-tap="toggleDrawer"></paper-icon-button>
+        <paper-icon-button icon="menu" on-click="toggleDrawer"></paper-icon-button>
       </app-toolbar>
 
       <sample-content size="100"></sample-content>

--- a/app-drawer/test/app-drawer.html
+++ b/app-drawer/test/app-drawer.html
@@ -723,9 +723,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(window.getComputedStyle(scrim)['visibility'], 'hidden');
       });
 
-      test('tap on scrim closes drawer', function() {
+      test('click on scrim closes drawer', function() {
         drawer.opened = true;
-        drawer.fire('tap', null /* detail */, { node: scrim });
+        drawer.fire('click', null /* detail */, { node: scrim });
 
         assert.isFalse(drawer.opened);
       });

--- a/app-drawer/test/index.html
+++ b/app-drawer/test/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'app-drawer.html',
-      'app-drawer.html?dom=shadow'
+      'app-drawer.html?wc-shadydom=true'
     ]);
   </script>
 </body>

--- a/demo/demo1.html
+++ b/demo/demo1.html
@@ -73,9 +73,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-header condenses reveals effects="waterfall">
       <app-toolbar>
-        <paper-icon-button icon="menu" on-tap="toggleLeft"></paper-icon-button>
+        <paper-icon-button icon="menu" on-click="toggleLeft"></paper-icon-button>
         <div main-title></div>
-        <paper-icon-button icon="shopping-cart" on-tap="toggleRight"></paper-icon-button>
+        <paper-icon-button icon="shopping-cart" on-click="toggleRight"></paper-icon-button>
       </app-toolbar>
       <app-toolbar></app-toolbar>
       <app-toolbar>

--- a/demo/demo6.html
+++ b/demo/demo6.html
@@ -113,7 +113,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script>
     var drawerLayout = document.getElementById('drawerLayout');
-    document.getElementById('toggle').addEventListener('tap', function() {
+    document.getElementById('toggle').addEventListener('click', function() {
       if (drawerLayout.forceNarrow || !drawerLayout.narrow) {
         drawerLayout.forceNarrow = !drawerLayout.forceNarrow;
       } else {


### PR DESCRIPTION
`assignedNodes()` doesn't seem to work with Shady DOM. This is causing `app-drawer-layout` tests to fail, even in Canary