### PR TITLE
Updates styles associated with paper-tabs within demo to be more tap friendly and have better result than what `bottom-item` can enable.

### DIFF
--- a/patterns/transform-navigation/x-app.html
+++ b/patterns/transform-navigation/x-app.html
@@ -36,8 +36,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
 
       paper-tabs {
-        max-width: 640px;
         --paper-tabs-selection-bar-color: black;
+        height: 100%;
+        max-width: 640px;
       }
 
       paper-tab {
@@ -75,7 +76,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           <app-toolbar class="tabs-bar" hidden$="{{!wideLayout}}">
             <!-- Nav on desktop: tabs -->
-            <paper-tabs selected="{{selected}}" attr-for-selected="name" bottom-item>
+            <paper-tabs selected="{{selected}}" attr-for-selected="name">
               <template is="dom-repeat" items="{{items}}">
                 <paper-tab name="{{item}}">{{item}}</paper-tab>
               </template>


### PR DESCRIPTION
Update the code of paper-tabs to improve its layout behavior & correct inconsistencies associated with its styling.

This removes problems such as the whole, vertical toolbar space occupied an individual tab not being clickable; users are not able to add new items alongside the paper-tabs as they're used to as explained by the app-toolbar docs for the scenario visually depicted by the demo on wide-screens, and ripple-effects actually ripple through the whole vertical and horizontal area area occupied by each individual tab.

## Expected outcome
1. If you click the top most region of the vertical space associated by each individual tab's horizontal bounds, things should change (including the ripple covering all the bounds)


## Actual outcome
1. Ripple doesn't work correctly. 
2. Tap area is significantly limited vertically associated with each tap

## Steps to reproduce
1. Wait for x-foo to render in a browser
2. Click the top most area ahead of the text associated with each tab
3. No selection happens. 

## Estimated Review Time
Review time should be no more than 5-10 minutes

## Unaddressed problems
1. The demo linked in the docs doesn't correctly hide the mobile-only toolbar with its usage of `hidden`, it causes the nav bar area to be much larger than needed.

2. Also, `<div main-title>{{selected}}</div> should probably be used in the mobile toolbar (the toolbar that's not hidden when `wideLayout` is false). 

 [My version](http://codepen.io/lozandier/pen/3783e361d4f8d53c04367d425fc11078) doesn't have such a problem; however, all I did was remove the makeshift `[hidden]` style selector and change the two-way binding to be one-way associated with the toolbar to hide when `wideLayout` is true which I don't expect to be primary reasons why it's fixed.

**Edit**: Needed `[hidden] { display: none !important}` the moment I turned on the use of Shadow DOM to render the component. 

## Recommended Reviewers
@frankiefu. 