### PR TITLE
Fix stacking context of 'shadow'

### DIFF
--- a/app-header/app-header.html
+++ b/app-header/app-header.html
@@ -235,7 +235,7 @@ Mixin | Description | Default
         transition-property: transform;
       }
 
-      :host::after {
+      :host::before {
         position: absolute;
         right: 0px;
         bottom: -5px;
@@ -251,7 +251,7 @@ Mixin | Description | Default
         @apply(--app-header-shadow);
       }
 
-      :host([shadow])::after {
+      :host([shadow])::before {
         opacity: 1;
       }
 


### PR DESCRIPTION
Fixes #392 by creating an appropriate stacking context between an app-header's content and its shadow