### PR TITLE
Add support for distributed children in app-grid

### DIFF
--- a/app-grid/app-grid-style.html
+++ b/app-grid/app-grid-style.html
@@ -121,7 +121,8 @@ Custom property                               | Description                     
   <template>
     <style>
 
-      :host {
+      :host,
+      :host ::content {
         /**
          * The width for the expandible item is:
          * ((100% - subPixelAdjustment) / columns * itemColumns - gutter
@@ -138,7 +139,8 @@ Custom property                               | Description                     
         };
       }
 
-      .app-grid {
+      .app-grid,
+      :host ::content .app-grid {
         display: -ms-flexbox;
         display: -webkit-flex;
         display: flex;
@@ -156,7 +158,8 @@ Custom property                               | Description                     
         box-sizing: border-box;
       }
 
-      .app-grid > * {
+      .app-grid > *,
+      :host ::content .app-grid > * {
         /* Required for IE 10 */
         -ms-flex: 1 1 100%;
         -webkit-flex: 1;
@@ -173,17 +176,20 @@ Custom property                               | Description                     
         box-sizing: border-box;
       }
 
-      .app-grid[has-aspect-ratio] > * {
+      .app-grid[has-aspect-ratio] > *,
+      :host ::content .app-grid[has-aspect-ratio] > * {
         position: relative;
       }
 
-      .app-grid[has-aspect-ratio] > *::before {
+      .app-grid[has-aspect-ratio] > *::before,
+      :host ::content .app-grid[has-aspect-ratio] > *::before {
         display: block;
         content: "";
         padding-top: var(--app-grid-item-height, 100%);
       }
 
-      .app-grid[has-aspect-ratio] > * > * {
+      .app-grid[has-aspect-ratio] > * > *,
+      :host ::content .app-grid[has-aspect-ratio] > * > * {
         position: absolute;
         top: 0;
         right: 0;

--- a/app-grid/demo/distributed-responsive-grid.html
+++ b/app-grid/demo/distributed-responsive-grid.html
@@ -1,0 +1,135 @@
+<!--
+@license
+Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+  <title>Responsive grid layout using app-grid-style with distributed children</title>
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../../polymer/polymer.html">
+  <link rel="import" href="../app-grid-style.html">
+
+  <style>
+
+    body {
+      margin: 0;
+      background-color: #ddd;
+    }
+
+    h1 {
+      font-family: 'Roboto', 'Noto', sans-serif;
+      text-align: center;
+      font-size: 18px;
+      line-height: 30px;
+      font-weight: 400;
+      margin: 10px 20px;
+    }
+
+  </style>
+</head>
+<body>
+  <dom-module id="x-app">
+    <template>
+      <style include="app-grid-style">
+
+        :host ::content {
+          display: block;
+          --app-grid-columns: 3;
+          --app-grid-gutter: 10px;
+          --app-grid-expandible-item-columns: 2;
+          --app-grid-item-height: 20vw;
+        }
+
+        :host ::content ul {
+          padding: 0;
+          list-style: none;
+        }
+
+        :host ::content .item {
+          list-style: none;
+          background-color: white;
+        }
+
+        @media (min-width: 800px) {
+          :host ::content .item:nth-child(5n+1) {
+            @apply(--app-grid-expandible-item);
+          }
+        }
+
+        @media (max-width: 799px) {
+          :host ::content {
+            --app-grid-columns: 2;
+            --app-grid-gutter: 5px;
+            --app-grid-expandible-item-columns: 2;
+          }
+
+          :host ::content .item:nth-child(3n+1) {
+            @apply(--app-grid-expandible-item);
+          }
+        }
+
+      </style>
+
+      <content></content>
+
+    </template>
+
+    <script>
+
+      HTMLImports.whenReady(function() {
+
+        Polymer({
+
+          is: 'x-app',
+
+          attached: function() {
+            this._updateGridStyles = this._updateGridStyles || function() {
+              this.updateStyles();
+            }.bind(this);
+            window.addEventListener('resize', this._updateGridStyles);
+          },
+
+          detached: function() {
+            window.removeEventListener('resize', this._updateGridStyles);
+          }
+
+        });
+
+      });
+
+    </script>
+  </dom-module>
+
+  <h1>3 columns on large screens and 2 columns on small ones.</h1>
+
+  <x-app>
+    <ul class="app-grid">
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+      <li class="item"></li>
+    </ul>
+  </x-app>
+
+</body>
+</html>

--- a/app-grid/demo/index.html
+++ b/app-grid/demo/index.html
@@ -33,6 +33,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <a href="flickr-grid-layout.html">Flickr grid layout</a>
         <a href="md-grid-layout.html">Material design grid layout</a>
         <a href="simple-responsive-grid.html">Simple responsive grid layout</a>
+        <a href="distributed-responsive-grid.html">Responsive grid layout with distributed children</a>
         <a href="aspect-ratio.html">Aspect ratios</a>
       </div>
     </div>

--- a/app-grid/test/app-grid-3-distributed.html
+++ b/app-grid/test/app-grid-3-distributed.html
@@ -1,0 +1,172 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>test for app-grid</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../../web-component-tester/browser.js"></script>
+  <script src="../../../test-fixture/test-fixture-mocha.js"></script>
+  <link rel="import" href="../../../test-fixture/test-fixture.html">
+  <link rel="import" href="../app-grid-style.html">
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+
+ <dom-module id="x-grid">
+    <template>
+      <style include="app-grid-style">
+
+        :host {
+          display: block;
+          --app-grid-columns: 4;
+          --app-grid-gutter: 16px;
+          --app-grid-expandible-item-columns: 3;
+          --app-grid-item-height: 100px;
+          width: 480px;
+          background-color: red;
+
+        }
+
+        ul {
+          margin: 0;
+          padding: 0;
+          list-style: none;
+        }
+
+        .item {
+          list-style: none;
+          background-color: green;
+        }
+
+        .item:nth-child(2),
+        .item:nth-child(3),
+        .item:nth-child(6),
+        .item:nth-child(7),
+        .item:nth-child(10) {
+            @apply(--app-grid-expandible-item);
+        }
+
+      </style>
+
+      <content></content>
+
+    </template>
+
+    <script>
+
+      HTMLImports.whenReady(function() {
+
+        Polymer({
+          is: 'x-grid'
+        });
+
+      });
+
+    </script>
+  </dom-module>
+
+
+  <test-fixture id="trivialGrid">
+    <template>
+      <x-grid>
+        <ul class="app-grid">
+          <li class="item">1</li>
+          <li class="item">2</li>
+          <li class="item">3</li>
+          <li class="item">4</li>
+          <li class="item">5</li>
+          <li class="item">6</li>
+          <li class="item">7</li>
+          <li class="item">8</li>
+          <li class="item">9</li>
+          <li class="item">10</li>
+          <li class="item">11</li>
+          <li class="item">12</li>
+          <li class="item">13</li>
+          <li class="item">14</li>
+        </ul>
+      </x-grid>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    function valueAsInt(obj) {
+      var rtn = {top: 0, right: 0, bottom: 0, left: 0, width: 0};
+      for (var k in obj) {
+        if (rtn.hasOwnProperty(k)) {
+          rtn[k] = Math.round(obj[k]);
+        }
+      }
+      return rtn;
+    }
+
+    suite('basic features', function() {
+      var grid;
+
+      setup(function() {
+        grid = fixture('trivialGrid');
+      });
+
+      test('bounding rectangle for each item', function(done) {
+
+        flush(function() {
+
+          var i, k, currentRect;
+          var gridItems = Polymer.dom(grid.root).querySelectorAll('li');
+          var expectedBoundingRect = [
+            {top: 16, right: 116, bottom: 116, left: 16, width: 100},
+            {top: 16, right: 464, bottom: 116, left: 132, width: 332},
+            {top: 132, right: 348, bottom: 232, left: 16, width: 332},
+            {top: 132, right: 464, bottom: 232, left: 364, width: 100},
+            {top: 248, right: 116, bottom: 348, left: 16, width: 100},
+            {top: 248, right: 464, bottom: 348, left: 132, width: 332},
+            {top: 364, right: 348, bottom: 464, left: 16, width: 332},
+            {top: 364, right: 464, bottom: 464, left: 364, width: 100},
+            {top: 480, right: 116, bottom: 580, left: 16, width: 100},
+            {top: 480, right: 464, bottom: 580, left: 132, width: 332},
+            {top: 596, right: 116, bottom: 696, left: 16, width: 100},
+            {top: 596, right: 232, bottom: 696, left: 132, width: 100},
+            {top: 596, right: 348, bottom: 696, left: 248, width: 100},
+            {top: 596, right: 464, bottom: 696, left: 364, width: 100}
+          ];
+
+          for (i = 0; i < gridItems.length; i++) {
+            currentRect = valueAsInt(gridItems[i].getBoundingClientRect());
+            for (k in expectedBoundingRect[i]) {
+              if (expectedBoundingRect[i].hasOwnProperty(k)) {
+                assert.approximately(expectedBoundingRect[i][k],
+                    currentRect[k], 4, ' ItemRect[' + i + '].' + k);
+              }
+            }
+          }
+
+         done();
+
+        });
+
+      });
+
+    });
+
+  </script>
+
+</body>
+</html>

--- a/app-grid/test/index.html
+++ b/app-grid/test/index.html
@@ -20,9 +20,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'app-grid-1.html',
       'app-grid-2.html',
       'app-grid-3.html',
+      'app-grid-3-distributed.html',
       'app-grid-1.html?dom=shadow',
       'app-grid-2.html?dom=shadow',
       'app-grid-3.html?dom=shadow',
+      'app-grid-3-distributed.html?dom=shadow',
     ]);
   </script>
 </body>


### PR DESCRIPTION
This fixes #394 by adding `:host ::content` to the app-grid-style selectors following instructions in https://www.polymer-project.org/1.0/docs/devguide/styling#styling-distributed-children-content.

I had to keep the previous selectors because tests didn't pass otherwise. If someone wants to check it or knows why that's happening my unsquashed commits are at https://github.com/ahaasler/app-layout/commits/distributed-children-app-grid-style. The first commit causes the app-grid tests to fail.