### PR TITLE
Add z-index to #contentContainer

### DIFF
--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -127,6 +127,8 @@ Custom property                          | Description                          
 
         height: 100%;
 
+        z-index: 1;
+
         transition: var(--app-drawer-layout-content-transition, none);
       }
 


### PR DESCRIPTION
Currently if there's for example `<google-youtube>` component inside and user tries to maximize that iframe, `<app-drawer>` will overlay maximized iframe:

![](https://i.imgur.com/BQSTBG8.png)

Live example: https://vaadin.github.io/elements-codelab/#0

This PR will fix that.