### PR TITLE
fix(template): prevent drawer from being swept open on larger screens

### DIFF
--- a/templates/shrine/src/shrine-app.html
+++ b/templates/shrine/src/shrine-app.html
@@ -216,7 +216,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <app-drawer-layout drawer-width="288px" force-narrow>
       <!-- navigation drawer for small screen sizes -->
-      <app-drawer id="drawer" swipe-open>
+      <app-drawer id="drawer" swipe-open="[[smallScreen]]">
         <template is="dom-if" if="[[smallScreen]]">
           <app-toolbar class="profileBar">
             <img class="profilePic" src="//app-layout-assets.appspot.com/assets/shrine/profile_pic.jpg"  width="30" height="30">


### PR DESCRIPTION
Fixes #434

This fixes #434 by binding the `swipe-open` attribute of `app-drawer` to the `smallScreen` media query. As a result, `swipe-open` is only enabled when the viewport is <= 400px wide.

I see that the [contributing guidelines](https://github.com/PolymerElements/app-layout/blob/master/CONTRIBUTING.md) state that tests must be added for bugfixes, but it seems that these templates do not have tests.