### PR TITLE
Added printer-friendly media queries to app-header-layout and app-drawer-layout

### DIFF
--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -149,8 +149,11 @@ a shadow root):
         z-index: 1;
       }
 
-      :host([fullbleed]) {
-        @apply --layout-fit;
+
+      @media not print {
+        :host([fullbleed]) {
+          @apply --layout-fit;
+        }
       }
 
       #contentContainer {

--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -149,11 +149,8 @@ a shadow root):
         z-index: 1;
       }
 
-
-      @media not print {
-        :host([fullbleed]) {
-          @apply --layout-fit;
-        }
+      :host([fullbleed]) {
+        @apply --layout-fit;
       }
 
       #contentContainer {

--- a/app-header-layout/app-header-layout.html
+++ b/app-header-layout/app-header-layout.html
@@ -86,45 +86,49 @@ Add the `fullbleed` attribute to app-header-layout to make it fit the size of it
         position: relative;
       }
 
-      @media not print {
-        :host([has-scrolling-region]) {
-          height: 100%;
-        }
+      :host([has-scrolling-region]) {
+        height: 100%;
+      }
 
-        :host([has-scrolling-region]) #wrapper ::slotted([slot=header]) {
-          position: absolute;
-        }
+      :host([has-scrolling-region]) #wrapper ::slotted([slot=header]) {
+        position: absolute;
+      }
 
-        :host([has-scrolling-region]) #wrapper.initializing ::slotted([slot=header]) {
-          position: relative;
-        }
+      :host([has-scrolling-region]) #wrapper.initializing ::slotted([slot=header]) {
+        position: relative;
+      }
 
-        :host([has-scrolling-region]) #wrapper #contentContainer {
-          @apply --layout-fit;
-          overflow-y: auto;
-          -webkit-overflow-scrolling: touch;
-        }
+      :host([has-scrolling-region]) #wrapper #contentContainer {
+        @apply --layout-fit;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
 
-        :host([has-scrolling-region]) #wrapper.initializing #contentContainer {
-          position: relative;
-        }
+      :host([has-scrolling-region]) #wrapper.initializing #contentContainer {
+        position: relative;
+      }
 
-        :host([fullbleed]) {
-          @apply --layout-vertical;
-          @apply --layout-fit;
-        }
+      :host([fullbleed]) {
+        @apply --layout-vertical;
+        @apply --layout-fit;
+      }
 
-        :host([fullbleed]) #wrapper,
-        :host([fullbleed]) #wrapper #contentContainer {
-          @apply --layout-vertical;
-          @apply --layout-flex;
-        }
+      :host([fullbleed]) #wrapper,
+      :host([fullbleed]) #wrapper #contentContainer {
+        @apply --layout-vertical;
+        @apply --layout-flex;
       }
 
       #contentContainer {
         /* Create a stacking context here so that all children appear below the header. */
         position: relative;
         z-index: 0;
+      }
+
+      @media print {
+        :host([has-scrolling-region]) #wrapper #contentContainer {
+          overflow-y: visible;
+        }
       }
 
     </style>

--- a/app-header-layout/app-header-layout.html
+++ b/app-header-layout/app-header-layout.html
@@ -86,37 +86,39 @@ Add the `fullbleed` attribute to app-header-layout to make it fit the size of it
         position: relative;
       }
 
-      :host([has-scrolling-region]) {
-        height: 100%;
-      }
+      @media not print {
+        :host([has-scrolling-region]) {
+          height: 100%;
+        }
 
-      :host([has-scrolling-region]) #wrapper ::slotted([slot=header]) {
-        position: absolute;
-      }
+        :host([has-scrolling-region]) #wrapper ::slotted([slot=header]) {
+          position: absolute;
+        }
 
-      :host([has-scrolling-region]) #wrapper.initializing ::slotted([slot=header]) {
-        position: relative;
-      }
+        :host([has-scrolling-region]) #wrapper.initializing ::slotted([slot=header]) {
+          position: relative;
+        }
 
-      :host([has-scrolling-region]) #wrapper #contentContainer {
-        @apply --layout-fit;
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-      }
+        :host([has-scrolling-region]) #wrapper #contentContainer {
+          @apply --layout-fit;
+          overflow-y: auto;
+          -webkit-overflow-scrolling: touch;
+        }
 
-      :host([has-scrolling-region]) #wrapper.initializing #contentContainer {
-        position: relative;
-      }
+        :host([has-scrolling-region]) #wrapper.initializing #contentContainer {
+          position: relative;
+        }
 
-      :host([fullbleed]) {
-        @apply --layout-vertical;
-        @apply --layout-fit;
-      }
+        :host([fullbleed]) {
+          @apply --layout-vertical;
+          @apply --layout-fit;
+        }
 
-      :host([fullbleed]) #wrapper,
-      :host([fullbleed]) #wrapper #contentContainer {
-        @apply --layout-vertical;
-        @apply --layout-flex;
+        :host([fullbleed]) #wrapper,
+        :host([fullbleed]) #wrapper #contentContainer {
+          @apply --layout-vertical;
+          @apply --layout-flex;
+        }
       }
 
       #contentContainer {


### PR DESCRIPTION
Fixes #487 

This fixes #487 by wrapping the [fullbleed] and [has-scrolling-region] related styles with a media query that excludes print.