### PR TITLE
Clarify code for tooling

### DIFF
--- a/helpers/helpers.html
+++ b/helpers/helpers.html
@@ -11,9 +11,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../../polymer/polymer.html">
 
 <script>
+  /** @namespace */
   Polymer.AppLayout = Polymer.AppLayout || {};
 
-  Polymer.AppLayout._scrollEffects = Polymer.AppLayout._scrollEffects || {};
+  Polymer.AppLayout._scrollEffects = {};
 
   Polymer.AppLayout.scrollTimingFunction = function easeOutQuad(t, b, c, d) {
     t /= d;


### PR DESCRIPTION
- `@namespace` clarifies that Polymer.AppLayout here is used as a global object to write to
- this file is responsible for `Polymer.AppLayout._scrollEffects`, it should not be initialized elsewhere