### PR TITLE
fixes to make closure compiler happy

### DIFF
--- a/helpers/helpers.html
+++ b/helpers/helpers.html
@@ -133,7 +133,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       // This seems to only apply when using document scrolling.
       // Therefore, when should we remove the class from the document element?
 
-      window.cancelAnimationFrame(Polymer.AppLayout._scrollTimer);
+      if (Polymer.AppLayout._scrollTimer) {
+        window.cancelAnimationFrame(Polymer.AppLayout._scrollTimer);
+      }
 
       Polymer.AppLayout._scrollTimer = window.requestAnimationFrame(function() {
         headers.forEach(function(header) {


### PR DESCRIPTION
Ensure we pass a number to `cancelAnimationFrame`.

Unfortunately I didn't catch this before merging #516 :[ 