### PR TITLE
'<' and '>' -> '&lt;' and '&gt;'

### DIFF
--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -45,9 +45,9 @@ Custom property                  | Description                            | Defa
 `--app-drawer-content-container` | Mixin for the drawer content container | {}
 `--app-drawer-scrim-background`  | Background for the scrim               | rgba(0, 0, 0, 0.5)
 
-**NOTE:** If you use <app-drawer> with <app-drawer-layout> and specify a value for
+**NOTE:** If you use `<app-drawer>` with `<app-drawer-layout>` and specify a value for
 `--app-drawer-width`, that value must be accessible by both elements. This can be done by
-defining the value on the `:host` that contains <app-drawer-layout> (or `html` if outside
+defining the value on the `:host` that contains `<app-drawer-layout>` (or `html` if outside
 a shadow root):
 
 ```css

--- a/app-drawer/app-drawer.html
+++ b/app-drawer/app-drawer.html
@@ -45,7 +45,7 @@ Custom property                  | Description                            | Defa
 `--app-drawer-content-container` | Mixin for the drawer content container | {}
 `--app-drawer-scrim-background`  | Background for the scrim               | rgba(0, 0, 0, 0.5)
 
-**NOTE:** If you use `<app-drawer>` with `<app-drawer-layout>` and specify a value for
+**NOTE:** If you use `&lt;app-drawer>` with `<app-drawer-layout>` and specify a value for
 `--app-drawer-width`, that value must be accessible by both elements. This can be done by
 defining the value on the `:host` that contains `<app-drawer-layout>` (or `html` if outside
 a shadow root):


### PR DESCRIPTION
Elements were being interpreted as html and not quoted, making the text nonsense.
I *think* this should fix that, but I can't think how to test it.

ref:
https://www.webcomponents.org/element/PolymerElements/app-layout/elements/app-drawer
```
NOTE:* If you use with and specify a value for --app-drawer-width, that value must be accessible by both
elements. This can be done by defining the value on the :host that contains (or html if outside a shadow
root):
```