### PR TITLE
Increase z-index of app-header-layout from 0 to 1

### DIFF
--- a/app-drawer-layout/app-drawer-layout.html
+++ b/app-drawer-layout/app-drawer-layout.html
@@ -141,7 +141,7 @@ a shadow root):
          * control the stacking of it relative to other elements.
          */
         position: relative;
-        z-index: 0;
+        z-index: 1;
       }
 
       :host ::slotted([slot=drawer]) {


### PR DESCRIPTION
With a z-index of 0, large `paper-dialogs` gets hidden behind the `app-drawer`. Changing the z-index to 1 fixes this problem.