### PR TITLE
Fixes to app-grid demo for Firefox and Edge

### DIFF
--- a/app-grid/demo/md-grid-layout.html
+++ b/app-grid/demo/md-grid-layout.html
@@ -52,6 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           --app-grid-gutter: 10px;
           --app-grid-expandible-item-columns: 4;
           --paper-icon-button-ink-color: white;
+          --app-grid-item-height: 200px;
         }
 
         app-header {
@@ -94,7 +95,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           padding: 16px;
         }
 
-        @media(max-width: 799px) {
+        @media screen and (max-width: 799px) {
 
           .centered-container {
             margin: 10px 5px;


### PR DESCRIPTION
Fix #528 
[https://github.com/PolymerElements/app-layout/issues/528](url)

Images fail to appear in Firefox as `--app-grid-item-height` is not set. Added to `:host` section as it only appears in the media query section.

Also added `screen and` to the media query as Edge seemed to ignore the query otherwise.

Re-tested the demo with Chrome 62, Opera 49 & 48, Firefox 57 & 56  Edge 40.15063.674.0.